### PR TITLE
add support for CEther interfaces

### DIFF
--- a/src/LibCompound.sol
+++ b/src/LibCompound.sol
@@ -3,18 +3,18 @@ pragma solidity 0.8.10;
 
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
-import {CERC20} from "./interfaces/CERC20.sol";
+import {ICERC20} from "./interfaces/ICERC20.sol";
 
 /// @notice Get up to date cToken data without mutating state.
 /// @author Transmissions11 (https://github.com/transmissions11/libcompound)
 library LibCompound {
     using FixedPointMathLib for uint256;
 
-    function viewUnderlyingBalanceOf(CERC20 cToken, address user) internal view returns (uint256) {
+    function viewUnderlyingBalanceOf(ICERC20 cToken, address user) internal view returns (uint256) {
         return cToken.balanceOf(user).fmul(viewExchangeRate(cToken), 1e18);
     }
 
-    function viewExchangeRate(CERC20 cToken) internal view returns (uint256) {
+    function viewExchangeRate(ICERC20 cToken) internal view returns (uint256) {
         uint256 accrualBlockNumberPrior = cToken.accrualBlockNumber();
 
         if (accrualBlockNumberPrior == block.number) return cToken.exchangeRateStored();

--- a/src/LibFuse.sol
+++ b/src/LibFuse.sol
@@ -3,18 +3,18 @@ pragma solidity 0.8.10;
 
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
-import {CERC20} from "./interfaces/CERC20.sol";
+import {ICERC20} from "./interfaces/ICERC20.sol";
 
 /// @notice Get up to date cToken data without mutating state.
 /// @author Transmissions11 (https://github.com/transmissions11/libcompound)
 library LibFuse {
     using FixedPointMathLib for uint256;
 
-    function viewUnderlyingBalanceOf(CERC20 cToken, address user) internal view returns (uint256) {
+    function viewUnderlyingBalanceOf(ICERC20 cToken, address user) internal view returns (uint256) {
         return cToken.balanceOf(user).fmul(viewExchangeRate(cToken), 1e18);
     }
 
-    function viewExchangeRate(CERC20 cToken) internal view returns (uint256) {
+    function viewExchangeRate(ICERC20 cToken) internal view returns (uint256) {
         uint256 accrualBlockNumberPrior = cToken.accrualBlockNumber();
 
         if (accrualBlockNumberPrior == block.number) return cToken.exchangeRateStored();

--- a/src/interfaces/ICERC20.sol
+++ b/src/interfaces/ICERC20.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+
+import "./ICToken.sol";
+
+interface ICERC20 is ICToken {
+    function mint(uint256) external virtual returns (uint256);
+
+    function borrow(uint256) external virtual returns (uint256);
+
+    function repayBorrowBehalf(address, uint256) external virtual returns (uint256);
+}

--- a/src/interfaces/ICEther.sol
+++ b/src/interfaces/ICEther.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+
+import "./ICToken.sol";
+
+interface ICERC20 is ICToken {
+    function mint() external payable;
+
+    function repayBorrow() external payable;
+
+    function repayBorrowBehalf(address borrower) external payable;
+}

--- a/src/interfaces/ICToken.sol
+++ b/src/interfaces/ICToken.sol
@@ -1,22 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.10;
 
-import {ERC20} from "solmate/tokens/ERC20.sol";
+pragma solidity ^0.8.0;
 
-import {InterestRateModel} from "./InterestRateModel.sol";
+import {IERC20} from "./IERC20.sol";
+import {IInterestRateModel} from "./IInterestRateModel.sol";
+import "./IERC20.sol";
 
-abstract contract CERC20 is ERC20 {
-    function mint(uint256) external virtual returns (uint256);
-
+interface ICToken is IERC20 {
     function borrow(uint256) external virtual returns (uint256);
 
-    function underlying() external view virtual returns (ERC20);
+    function underlying() external view virtual returns (IERC20);
 
     function totalBorrows() external view virtual returns (uint256);
 
     function totalFuseFees() external view virtual returns (uint256);
-
-    function repayBorrow(uint256) external virtual returns (uint256);
 
     function totalReserves() external view virtual returns (uint256);
 
@@ -40,9 +37,7 @@ abstract contract CERC20 is ERC20 {
 
     function borrowBalanceCurrent(address) external virtual returns (uint256);
 
-    function interestRateModel() external view virtual returns (InterestRateModel);
+    function interestRateModel() external view virtual returns (IInterestRateModel);
 
     function initialExchangeRateMantissa() external view virtual returns (uint256);
-
-    function repayBorrowBehalf(address, uint256) external virtual returns (uint256);
 }

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity ^0.8.10;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/src/interfaces/IInterestRateModel.sol
+++ b/src/interfaces/IInterestRateModel.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.10;
 
-interface InterestRateModel {
+interface IInterestRateModel {
     function getBorrowRate(
         uint256,
         uint256,

--- a/src/test/LibCompound.t.sol
+++ b/src/test/LibCompound.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.10;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 
-import {CERC20} from "../interfaces/CERC20.sol";
+import {ICERC20} from "../interfaces/ICERC20.sol";
 
 import {LibCompound} from "../LibCompound.sol";
 
 contract LibCompoundTest is DSTestPlus {
-    CERC20 cDAI = CERC20(address(0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643));
+    ICERC20 cDAI = ICERC20(address(0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643));
 
     address cDAIHolder = 0xA2B47E3D5c44877cca798226B7B8118F9BFb7A56;
 

--- a/src/test/LibFuse.t.sol
+++ b/src/test/LibFuse.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.10;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 
-import {CERC20} from "../interfaces/CERC20.sol";
+import {ICERC20} from "../interfaces/ICERC20.sol";
 
 import {LibFuse} from "../LibFuse.sol";
 
 contract LibFuseTest is DSTestPlus {
-    CERC20 f6DAI = CERC20(address(0x989273ec41274C4227bCB878C2c26fdd3afbE70d));
+    ICERC20 f6DAI = ICERC20(address(0x989273ec41274C4227bCB878C2c26fdd3afbE70d));
 
     address f6DAIHolder = 0x81649be6A4f00E3098DA5ff4b166122de4f05cC1;
 


### PR DESCRIPTION
It's useful to be able to support both ERC20s and Ether, as well as to remove the dependency on the solmate ERC20 implementation, favoring the EIP defined interface.