### PR TITLE
Accommodate early cTokens (cUSDC & others?)

### DIFF
--- a/src/LibCompound.sol
+++ b/src/LibCompound.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.10;
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {CERC20} from "./interfaces/CERC20.sol";
-import {CERC20a} from "./interfaces/CERC20a.sol";
+import {CERC20a} from "./interfaces/CERC20a.sol"; 
 
 /// @notice Get up to date cToken data without mutating state.
 /// @author Transmissions11 (https://github.com/transmissions11/libcompound)
 library LibCompound {
     using FixedPointMathLib for uint256;
 
-    error RATE_TOO_HIGH;
+    error RATE_TOO_HIGH();
 
     function viewUnderlyingBalanceOf(CERC20 cToken, address user) internal view returns (uint256) {
         return cToken.balanceOf(user).mulWadDown(viewExchangeRate(cToken));

--- a/src/LibCompound.sol
+++ b/src/LibCompound.sol
@@ -29,10 +29,10 @@ library LibCompound {
         uint256 borrowRateMantissa = cToken.interestRateModel().getBorrowRate(totalCash, borrowsPrior, reservesPrior);
 
         if (borrowRateMantissa < 100) {
-            (, borrowRateMantissa = CERC20a(address(cToken)).interestRateModel().getBorrowRate(totalCash, borrowsPrior, reservesPrior);)
+            (, borrowRateMantissa) = CERC20a(address(cToken)).interestRateModel().getBorrowRate(totalCash, borrowsPrior, reservesPrior); 
         }
 
-        if (borrowRateMantissa > 0.0005e16) {revert RATE_TOO_HIGH} // Same as borrowRateMaxMantissa in CTokenInterfaces.sol
+        if (borrowRateMantissa > 0.0005e16) { revert RATE_TOO_HIGH(); } // Same as borrowRateMaxMantissa in CTokenInterfaces.sol
 
         uint256 interestAccumulated = (borrowRateMantissa * (block.number - accrualBlockNumberPrior)).mulWadDown(
             borrowsPrior

--- a/src/LibCompound.sol
+++ b/src/LibCompound.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.10;
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 
 import {CERC20} from "./interfaces/CERC20.sol";
+import {CERC20a} from "./interfaces/CERC20a.sol";
 
 /// @notice Get up to date cToken data without mutating state.
 /// @author Transmissions11 (https://github.com/transmissions11/libcompound)
@@ -24,6 +25,10 @@ library LibCompound {
         uint256 reservesPrior = cToken.totalReserves();
 
         uint256 borrowRateMantissa = cToken.interestRateModel().getBorrowRate(totalCash, borrowsPrior, reservesPrior);
+
+        if (borrowRateMantissa <= 100) {
+            (, borrowRateMantissa = CERC20a(address(cToken)).interestRateModel().getBorrowRate(totalCash, borrowsPrior, reservesPrior);)
+        }
 
         require(borrowRateMantissa <= 0.0005e16, "RATE_TOO_HIGH"); // Same as borrowRateMaxMantissa in CTokenInterfaces.sol
 

--- a/src/interfaces/CERC20a.sol
+++ b/src/interfaces/CERC20a.sol
@@ -5,7 +5,7 @@ import {ERC20} from "solmate/tokens/ERC20.sol";
 
 import {InterestRateModelA} from "./InterestRateModelA.sol";
 
-abstract contract CERC20 is ERC20 {
+abstract contract CERC20a is ERC20 {
     function mint(uint256) external virtual returns (uint256);
 
     function borrow(uint256) external virtual returns (uint256);

--- a/src/interfaces/CERC20a.sol
+++ b/src/interfaces/CERC20a.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+import {ERC20} from "solmate/tokens/ERC20.sol";
+
+import {InterestRateModelA} from "./InterestRateModelA.sol";
+
+abstract contract CERC20 is ERC20 {
+    function mint(uint256) external virtual returns (uint256);
+
+    function borrow(uint256) external virtual returns (uint256);
+
+    function underlying() external view virtual returns (ERC20);
+
+    function totalBorrows() external view virtual returns (uint256);
+
+    function totalFuseFees() external view virtual returns (uint256);
+
+    function repayBorrow(uint256) external virtual returns (uint256);
+
+    function totalReserves() external view virtual returns (uint256);
+
+    function exchangeRateCurrent() external virtual returns (uint256);
+
+    function totalAdminFees() external view virtual returns (uint256);
+
+    function fuseFeeMantissa() external view virtual returns (uint256);
+
+    function adminFeeMantissa() external view virtual returns (uint256);
+
+    function exchangeRateStored() external view virtual returns (uint256);
+
+    function accrualBlockNumber() external view virtual returns (uint256);
+
+    function redeemUnderlying(uint256) external virtual returns (uint256);
+
+    function balanceOfUnderlying(address) external virtual returns (uint256);
+
+    function reserveFactorMantissa() external view virtual returns (uint256);
+
+    function borrowBalanceCurrent(address) external virtual returns (uint256);
+
+    function interestRateModel() external view virtual returns (InterestRateModelA);
+
+    function initialExchangeRateMantissa() external view virtual returns (uint256);
+
+    function repayBorrowBehalf(address, uint256) external virtual returns (uint256);
+}

--- a/src/interfaces/InterestRateModelA.sol
+++ b/src/interfaces/InterestRateModelA.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+interface InterestRateModelA {
+    function getBorrowRate(
+        uint256,
+        uint256,
+        uint256
+    ) external view returns (uint256, uint256);
+
+    function getSupplyRate(
+        uint256,
+        uint256,
+        uint256,
+        uint256
+    ) external view returns (uint256);
+}


### PR DESCRIPTION
Covering Issue #6 which discusses some old/deprecated cTokens, specifically cUSDC.

1. Get borrowRateMantissa on current CERC20

In cases where they are instead the deprecated tokens, they return (success, borrowRateMantissa), storing the `success` flag in in `uint256 borrowRateMantissa`

2. Check for the `success` flag. On Compound returns `0` for success, and `1`-`77` for various error codes.

3. If a `success` flag was received instead of a borrowRateMantissa (`borrowRateMantissa` < 100, leaving room for 23 more error additions)

4. Then utilize the alternate CERC20 interface, overwriting the `borrowRateMantissa` success flag with an actual borrowRateMantissa.